### PR TITLE
Initial manifest

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -46,3 +46,11 @@ spack:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
       tag: 2026.07.013
       destination: $env/package-repos/access-spack-packages
+  modules:
+    default:
+      tcl:
+        include:
+        - cable
+        projections:
+          # build-cd will inject the _version into this projection
+          cable: '{name}/{version}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,48 +5,42 @@
 spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
-  - _name: # [DEPLOYMENT_NAME_HERE]
-  - _version: # [DEPLOYMENT_VERSION_HERE]
-  # NOTE: This manifest is an unfinished template - _name, _version and specs still need to be filled in.
-  # The following reserved definitions were migrated from config/versions.json and config/packages.json.
+  - _name: [cable]
+  - _version: [2026.09.001]
   # _spack-version informs the branch of spack to use
   - _spack-version: ["1.1"]
   # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
-  - _provenance: []
-  - _injection: ["openmpi"]
+  - _provenance: ["cable"]
   specs:
-  # The root Spack Bundle Recipe (SBR) for the model and overall version of
-  # the deployment:
-  # TODO: Replace the MODEL.
-  # - MODEL
+  - cable
   packages:
-    # Specification of dependency versions and variants. CI/CD requires that
-    # the first element of the require is only a version:
-    # TODO: Specify versions and variants of dependencies as required.
-    # openmpi:
-    #   require:
-    #   - '@4.1.5'
+     cable:
+       require:
+       - '@git.2026.07.000'
+    # Indirect dependencies
+    netcdf-c:
+      require:
+      - '@4.9.2'
+
+    netcdf-fortran:
+      require:
+      - '@4.5.2'
 
     # Compilers
-    # c:
-    #  require:
-    #  - intel-oneapi-compilers-classic@19.0.5.281
-    # cxx:
-    #  require:
-    #  - intel-oneapi-compilers-classic@19.0.5.281
-    # fortran:
-    #   require:
-    #   - intel-oneapi-compilers-classic@19.0.5.281
-    # Specifications that apply to all packages
-    all:
-    # TODO: Specify targets for all packages
-    # require:
-    # - 'target=x86_64_v3'
+    c:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
+    cxx:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
+    fortran:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
   view: true
   concretizer:
     unify: true
   repos:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
-      tag: 2026.02.002
+      tag: 2026.07.013
       destination: $env/package-repos/access-spack-packages

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,6 +18,7 @@ spack:
     cable:
       require:
       - '@git.2026.07.000'
+      - ~mpi
     # Indirect dependencies
     netcdf-c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,9 +14,9 @@ spack:
   specs:
   - cable
   packages:
-     cable:
-       require:
-       - '@git.2026.07.000'
+    cable:
+      require:
+      - '@git.2026.07.000'
     # Indirect dependencies
     netcdf-c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,6 +11,7 @@ spack:
   - _spack-version: ["1.1"]
   # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
   - _provenance: ["cable"]
+  - _injection: []
   specs:
   - cable
   packages:


### PR DESCRIPTION
Initial manifest. Versions copied from ACCESS-AM3 manifest.

Closes #1 

---
:rocket: The latest prerelease `cable/pr15-3` at c22d219b0f4bd1daf82e63f65805ed6bf10a4b44 is here: https://github.com/ACCESS-NRI/CABLE-standalone/pull/15#issuecomment-5506110083 :rocket:


